### PR TITLE
Fix linter errors

### DIFF
--- a/footer.go
+++ b/footer.go
@@ -1,13 +1,11 @@
 package ksef
 
-import (
-	"github.com/invopop/gobl/bill"
-)
-
+// Footer element of the KSeF invoice
 type Footer struct {
 }
 
-func NewFooter(inv *bill.Invoice) *Footer {
+// NewFooter generates footer element for KSeF invoice
+func NewFooter() *Footer {
 
 	footer := &Footer{}
 

--- a/header.go
+++ b/header.go
@@ -16,6 +16,7 @@ const (
 	systemInfo    = "GOBL.KSEF"
 )
 
+// Header defines the XML structure for KSeF header
 type Header struct {
 	FormCode     *FormCode `xml:"KodFormularza"`
 	FormVariant  int       `xml:"WariantFormularza"`
@@ -23,12 +24,14 @@ type Header struct {
 	SystemInfo   string    `xml:"SystemInfo"`
 }
 
+// FormCode defines the XML structure for KSeF schema versioning
 type FormCode struct {
 	SystemCode    string `xml:"kodSystemowy,attr"`
 	SchemaVersion string `xml:"wersjaSchemy,attr"`
 	FormCode      string `xml:",chardata"`
 }
 
+// NewHeader gets header data from GOBL invoice
 func NewHeader(inv *bill.Invoice) *Header {
 	date := formatIssueDate(inv.IssueDate)
 

--- a/invoice.go
+++ b/invoice.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// Inv defines the XML structure for KSeF invoice
 type Inv struct {
 	CurrencyCode                       string       `xml:"KodWaluty"`
 	IssueDate                          string       `xml:"P_1"`
@@ -33,10 +34,10 @@ type Inv struct {
 	IntraCommunityNetSale              string       `xml:"P_13_6_2,omitempty"`
 	ExportNetSale                      string       `xml:"P_13_6_3,omitempty"`
 	TaxExemptNetSale                   string       `xml:"P_13_7,omitempty"`
-	P_13_8                             string       `xml:"P_13_8,omitempty"`
-	P_13_9                             string       `xml:"P_13_9,omitempty"`
-	P_13_10                            string       `xml:"P_13_10,omitempty"`
-	P_13_11                            string       `xml:"P_13_11,omitempty"`
+	InternationalNetSale               string       `xml:"P_13_8,omitempty"`
+	OtherNetSale                       string       `xml:"P_13_9,omitempty"`
+	EUServiceNetSale                   string       `xml:"P_13_10,omitempty"`
+	MarginNetSale                      string       `xml:"P_13_11,omitempty"`
 	TotalAmountReceivable              string       `xml:"P_15"`
 	Annotations                        *Annotations `xml:"Adnotacje"`
 	InvoiceType                        string       `xml:"RodzajFaktury"`
@@ -44,6 +45,7 @@ type Inv struct {
 	Payment                            *Payment     `xml:"Platnosc"`
 }
 
+// Annotations defines the XML structure for KSeF annotations
 type Annotations struct {
 	CashAccounting                      int `xml:"P_16"`
 	SelfBilling                         int `xml:"P_17"`
@@ -55,7 +57,8 @@ type Annotations struct {
 	NoMarginProcedures                  int `xml:"PMarzy>P_PMarzyN"`
 }
 
-func NewAnnotations(inv *bill.Invoice) *Annotations {
+// newAnnotations sets annotations data
+func newAnnotations() *Annotations {
 	// default values for the most common case,
 	// For fields P_16 to P_18 and field P_23 2 means "no", 1 means "yes".
 	// for others 1 means "yes", no value means "no"
@@ -72,10 +75,11 @@ func NewAnnotations(inv *bill.Invoice) *Annotations {
 	return Annotations
 }
 
+// NewInv gets invoice data from GOBL invoice
 func NewInv(inv *bill.Invoice) *Inv {
 	cu := inv.Currency.Def().Units
 	Inv := &Inv{
-		Annotations:           NewAnnotations(inv),
+		Annotations:           newAnnotations(),
 		CurrencyCode:          string(inv.Currency),
 		IssueDate:             inv.IssueDate.String(),
 		SequentialNumber:      inv.Series + inv.Code,

--- a/ksef.go
+++ b/ksef.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/bill"
 )
 
+// Constants for KSeF XML
 const (
 	XSINamespace    = "http://www.w3.org/2001/XMLSchema-instance"
 	XSDNamespace    = "http://www.w3.org/2001/XMLSchema"
@@ -47,7 +48,7 @@ func NewDocument(env *gobl.Envelope) (*Invoice, error) {
 		Seller: NewSeller(inv.Supplier),
 		Buyer:  NewBuyer(inv.Customer),
 		Inv:    NewInv(inv),
-		Footer: NewFooter(inv),
+		Footer: NewFooter(),
 	}
 
 	return invoice, nil

--- a/ksef_test.go
+++ b/ksef_test.go
@@ -29,34 +29,34 @@ func TestNewDocument(t *testing.T) {
 		doc, err := test.NewDocumentFrom("invoice-pl-pl.json")
 		require.NoError(t, err)
 
-		bytes, bytesErr := doc.Bytes()
-		require.NoError(t, bytesErr)
+		data, err := doc.Bytes()
+		require.NoError(t, err)
 
-		output, outputErr := test.LoadOutputFile("invoice-pl-pl.xml")
-		require.NoError(t, outputErr)
+		output, err := test.LoadOutputFile("invoice-pl-pl.xml")
+		require.NoError(t, err)
 
-		assert.Equal(t, output, bytes)
+		assert.Equal(t, output, data)
 	})
 
 	t.Run("should generate valid KSeF document", func(t *testing.T) {
-		xsdvalidateErr := xsdvalidate.Init()
-		require.NoError(t, xsdvalidateErr)
+		err := xsdvalidate.Init()
+		require.NoError(t, err)
 		defer xsdvalidate.Cleanup()
 
-		xsdBuf, xsdErr := test.LoadSchemaFile("FA2.xsd")
-		require.NoError(t, xsdErr)
+		xsdBuf, err := test.LoadSchemaFile("FA2.xsd")
+		require.NoError(t, err)
 
-		xsdhandler, xsdhandlerErr := xsdvalidate.NewXsdHandlerMem(xsdBuf, xsdvalidate.ParsErrVerbose)
-		require.NoError(t, xsdhandlerErr)
+		xsdhandler, err := xsdvalidate.NewXsdHandlerMem(xsdBuf, xsdvalidate.ParsErrVerbose)
+		require.NoError(t, err)
 		defer xsdhandler.Free()
 
 		doc, err := test.NewDocumentFrom("invoice-pl-pl.json")
 		require.NoError(t, err)
 
-		bytes, bytesErr := doc.Bytes()
-		require.NoError(t, bytesErr)
+		data, err := doc.Bytes()
+		require.NoError(t, err)
 
-		validationErr := xsdhandler.ValidateMem(bytes, xsdvalidate.ParsErrDefault)
-		assert.Nil(t, validationErr)
+		validation := xsdhandler.ValidateMem(data, xsdvalidate.ParsErrDefault)
+		assert.Nil(t, validation)
 	})
 }

--- a/ksef_test.go
+++ b/ksef_test.go
@@ -29,34 +29,34 @@ func TestNewDocument(t *testing.T) {
 		doc, err := test.NewDocumentFrom("invoice-pl-pl.json")
 		require.NoError(t, err)
 
-		bytes, bytes_err := doc.Bytes()
-		require.NoError(t, bytes_err)
+		bytes, bytesErr := doc.Bytes()
+		require.NoError(t, bytesErr)
 
-		output, output_err := test.LoadOutputFile("invoice-pl-pl.xml")
-		require.NoError(t, output_err)
+		output, outputErr := test.LoadOutputFile("invoice-pl-pl.xml")
+		require.NoError(t, outputErr)
 
 		assert.Equal(t, output, bytes)
 	})
 
 	t.Run("should generate valid KSeF document", func(t *testing.T) {
-		xsdvalidate_err := xsdvalidate.Init()
-		require.NoError(t, xsdvalidate_err)
+		xsdvalidateErr := xsdvalidate.Init()
+		require.NoError(t, xsdvalidateErr)
 		defer xsdvalidate.Cleanup()
 
-		xsd_buf, xsd_err := test.LoadSchemaFile("FA2.xsd")
-		require.NoError(t, xsd_err)
+		xsdBuf, xsdErr := test.LoadSchemaFile("FA2.xsd")
+		require.NoError(t, xsdErr)
 
-		xsdhandler, xsdhandler_err := xsdvalidate.NewXsdHandlerMem(xsd_buf, xsdvalidate.ParsErrVerbose)
-		require.NoError(t, xsdhandler_err)
+		xsdhandler, xsdhandlerErr := xsdvalidate.NewXsdHandlerMem(xsdBuf, xsdvalidate.ParsErrVerbose)
+		require.NoError(t, xsdhandlerErr)
 		defer xsdhandler.Free()
 
 		doc, err := test.NewDocumentFrom("invoice-pl-pl.json")
 		require.NoError(t, err)
 
-		bytes, bytes_err := doc.Bytes()
-		require.NoError(t, bytes_err)
+		bytes, bytesErr := doc.Bytes()
+		require.NoError(t, bytesErr)
 
-		validation_err := xsdhandler.ValidateMem(bytes, xsdvalidate.ParsErrDefault)
-		assert.Nil(t, validation_err)
+		validationErr := xsdhandler.ValidateMem(bytes, xsdvalidate.ParsErrDefault)
+		assert.Nil(t, validationErr)
 	})
 }

--- a/lines.go
+++ b/lines.go
@@ -2,6 +2,7 @@ package ksef
 
 import "github.com/invopop/gobl/bill"
 
+// Line defines the XML structure for KSeF item line
 type Line struct {
 	LineNumber              int    `xml:"NrWierszaFa"`
 	Name                    string `xml:"P_7"`
@@ -19,7 +20,7 @@ type Line struct {
 	BeforeCorrectionMarker  string `xml:"StanPrzed,omitempty"`
 }
 
-func NewLine(line *bill.Line) *Line {
+func newLine(line *bill.Line) *Line {
 	Line := &Line{
 		LineNumber:    line.Index,
 		Name:          line.Item.Name,
@@ -34,11 +35,12 @@ func NewLine(line *bill.Line) *Line {
 	return Line
 }
 
+// NewLines generates lines for the KSeF invoice
 func NewLines(lines []*bill.Line) []*Line {
 	var Lines []*Line
 
 	for _, line := range lines {
-		Lines = append(Lines, NewLine(line))
+		Lines = append(Lines, newLine(line))
 	}
 
 	return Lines

--- a/parties.go
+++ b/parties.go
@@ -5,12 +5,14 @@ import (
 	"github.com/invopop/gobl/org"
 )
 
+// Address defines the XML structure for KSeF addresses
 type Address struct {
 	CountryCode string `xml:"KodKraju"`
 	AddressL1   string `xml:"AdresL1"`
 	AddressL2   string `xml:"AdresL2"`
 }
 
+// Seller defines the XML structure for KSeF seller
 type Seller struct {
 	NIP     string          `xml:"DaneIdentyfikacyjne>NIP"`
 	Name    string          `xml:"DaneIdentyfikacyjne>Nazwa"`
@@ -18,11 +20,13 @@ type Seller struct {
 	Contact *ContactDetails `xml:"DaneKontaktowe,omitempty"`
 }
 
+// ContactDetails defines the XML structure for KSeF contact
 type ContactDetails struct {
 	Phone string `xml:"Telefon,omitempty"`
 	Email string `xml:"Email,omitempty"`
 }
 
+// Buyer defines the XML structure for KSeF buyer
 type Buyer struct {
 	NIP string `xml:"DaneIdentyfikacyjne>NIP,omitempty"`
 	// or
@@ -30,15 +34,16 @@ type Buyer struct {
 	UEVatNumber string `xml:"DaneIdentyfikacyjne>NrVatUE,omitempty"`
 	// or
 	CountryCode string `xml:"DaneIdentyfikacyjne>KodKraju,omitempty"`
-	IdNumber    string `xml:"DaneIdentyfikacyjne>NrId,omitempty"`
+	IDNumber    string `xml:"DaneIdentyfikacyjne>NrId,omitempty"`
 	// or
-	NoId int `xml:"DaneIdentyfikacyjne>BrakID,omitempty"`
+	NoID int `xml:"DaneIdentyfikacyjne>BrakID,omitempty"`
 
 	Name    string          `xml:"DaneIdentyfikacyjne>Nazwa,omitempty"`
 	Address *Address        `xml:"Adres,omitempty"`
 	Contact *ContactDetails `xml:"DaneKontaktowe,omitempty"`
 }
 
+// NewAddress gets the address data from GOBL address
 func NewAddress(address *org.Address) *Address {
 	adres := &Address{
 		CountryCode: string(address.Country),
@@ -49,12 +54,14 @@ func NewAddress(address *org.Address) *Address {
 	return adres
 }
 
+// NameToString get the seller name out of the organization
 func NameToString(name org.Name) string {
 	return name.Prefix + nameMaybe(name.Given) +
 		nameMaybe(name.Middle) + nameMaybe(name.Surname) +
 		nameMaybe(name.Surname2) + nameMaybe(name.Suffix)
 }
 
+// NewSeller converts a GOBL Party into a KSeF seller
 func NewSeller(supplier *org.Party) *Seller {
 	var name string
 	if supplier.Name != "" {
@@ -82,6 +89,7 @@ func NewSeller(supplier *org.Party) *Seller {
 	return seller
 }
 
+// NewBuyer converts a GOBL Party into a KSeF buyer
 func NewBuyer(customer *org.Party) *Buyer {
 
 	buyer := &Buyer{
@@ -93,10 +101,10 @@ func NewBuyer(customer *org.Party) *Buyer {
 		buyer.NIP = string(customer.TaxID.Code)
 	} else {
 		if len(customer.TaxID.Code) > 0 {
-			buyer.IdNumber = string(customer.TaxID.Code)
+			buyer.IDNumber = string(customer.TaxID.Code)
 			buyer.CountryCode = string(customer.TaxID.Country)
 		} else {
-			buyer.NoId = 1
+			buyer.NoID = 1
 		}
 	}
 	// TODO NrVatUE and UECode if applicable

--- a/payments.go
+++ b/payments.go
@@ -9,16 +9,19 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// AdvancePayment defines the XML structure for KSeF advance payments
 type AdvancePayment struct {
 	PaymentAmount string `xml:"KwotaZaplatyCzesciowej,omitempty"`
 	PaymentDate   string `xml:"DataZaplatyCzesciowej,omitempty"`
 }
 
+// PartialPayment defines the XML structure for KSeF due date
 type PartialPayment struct {
 	Date        string `xml:"Termin,omitempty"`
 	Description string `xml:"TerminOpis,omitempty"`
 }
 
+// BankAccount defines the XML structure for KSeF bank accounts
 type BankAccount struct {
 	AccountNumber         string `xml:"NrRB"`
 	SWIFT                 string `xml:"SWIFT,omitempty"`
@@ -27,11 +30,13 @@ type BankAccount struct {
 	AccountDescription    string `xml:"OpisRachunku,omitempty"`
 }
 
+// Discount defines the XML structure for KSeF discount
 type Discount struct { // TODO
 	Conditions string `xml:"WarunkiSkonta,omitempty"`
 	Amount     string `xml:"WysokoscSkonta,omitempty"`
 }
 
+// Payment defines the XML structure for KSeF payment
 type Payment struct {
 	PaidMarker             string            `xml:"Zaplacono,omitempty"`
 	PaymentDate            string            `xml:"DataZaplaty,omitempty"`
@@ -46,6 +51,7 @@ type Payment struct {
 	Discount               *Discount         `xml:"Skonto,omitempty"`                 // it's some special discount for early payments
 }
 
+// NewPayment gets payment data from GOBL invoice
 func NewPayment(inv *bill.Invoice) *Payment {
 
 	var payment = &Payment{

--- a/test/test.go
+++ b/test/test.go
@@ -72,7 +72,7 @@ func LoadOutputFile(name string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// LoadOutputFile returns byte data from a file in the `test/data/out` folder
+// LoadSchemaFile returns byte data from a file in the `test/data/schema` folder
 func LoadSchemaFile(name string) ([]byte, error) {
 	src, _ := os.Open(filepath.Join(GetSchemaPath(), name))
 
@@ -84,7 +84,7 @@ func LoadSchemaFile(name string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// GetOutPath returns the path to the `test/data/schema` folder
+// GetSchemaPath returns the path to the `test/data/schema` folder
 func GetSchemaPath() string {
 	return filepath.Join(GetDataPath(), "schema")
 }


### PR DESCRIPTION
## Pull Request Summary

The recent chnages to the linter exposed some tech debt that we want to fix to be up to date with the best practices. Here we fix all the linter errors that our new linters caught. These are mostly missing comments for exported methods but it also caught some unused parameters and we changed the visibility of some methods since they are only used internally.