### PR TITLE
Add omitempty to fields that can be empty according to KSeF schema

### DIFF
--- a/header.go
+++ b/header.go
@@ -21,7 +21,7 @@ type Header struct {
 	FormCode     *FormCode `xml:"KodFormularza"`
 	FormVariant  int       `xml:"WariantFormularza"`
 	CreationDate string    `xml:"DataWytworzeniaFa"`
-	SystemInfo   string    `xml:"SystemInfo"`
+	SystemInfo   string    `xml:"SystemInfo,omitempty"`
 }
 
 // FormCode defines the XML structure for KSeF schema versioning

--- a/lines.go
+++ b/lines.go
@@ -5,13 +5,13 @@ import "github.com/invopop/gobl/bill"
 // Line defines the XML structure for KSeF item line
 type Line struct {
 	LineNumber              int    `xml:"NrWierszaFa"`
-	Name                    string `xml:"P_7"`
-	Measure                 string `xml:"P_8A"`
-	Quantity                string `xml:"P_8B"`
-	NetUnitPrice            string `xml:"P_9A"`
-	UnitDiscount            string `xml:"P_10"`
-	NetPriceTotal           string `xml:"P_11"`
-	TaxRate                 string `xml:"P_12"`
+	Name                    string `xml:"P_7,omitempty"`
+	Measure                 string `xml:"P_8A,omitempty"`
+	Quantity                string `xml:"P_8B,omitempty"`
+	NetUnitPrice            string `xml:"P_9A,omitempty"`
+	UnitDiscount            string `xml:"P_10,omitempty"`
+	NetPriceTotal           string `xml:"P_11,omitempty"`
+	TaxRate                 string `xml:"P_12,omitempty"`
 	ExciseDuty              string `xml:"KwotaAkcyzy,omitempty"`
 	SpecialGoodsCode        string `xml:"GTU,omitempty"` // values GTU_1 to GTU_13
 	OSSTaxRate              string `xml:"P_12_XII,omitempty"`

--- a/parties.go
+++ b/parties.go
@@ -9,7 +9,7 @@ import (
 type Address struct {
 	CountryCode string `xml:"KodKraju"`
 	AddressL1   string `xml:"AdresL1"`
-	AddressL2   string `xml:"AdresL2"`
+	AddressL2   string `xml:"AdresL2,omitempty"`
 }
 
 // Seller defines the XML structure for KSeF seller
@@ -43,8 +43,8 @@ type Buyer struct {
 	Contact *ContactDetails `xml:"DaneKontaktowe,omitempty"`
 }
 
-// NewAddress gets the address data from GOBL address
-func NewAddress(address *org.Address) *Address {
+// newAddress gets the address data from GOBL address
+func newAddress(address *org.Address) *Address {
 	adres := &Address{
 		CountryCode: string(address.Country),
 		AddressL1:   addressLine1(address),
@@ -54,8 +54,8 @@ func NewAddress(address *org.Address) *Address {
 	return adres
 }
 
-// NameToString get the seller name out of the organization
-func NameToString(name org.Name) string {
+// nameToString get the seller name out of the organization
+func nameToString(name org.Name) string {
 	return name.Prefix + nameMaybe(name.Given) +
 		nameMaybe(name.Middle) + nameMaybe(name.Surname) +
 		nameMaybe(name.Surname2) + nameMaybe(name.Suffix)
@@ -67,10 +67,10 @@ func NewSeller(supplier *org.Party) *Seller {
 	if supplier.Name != "" {
 		name = supplier.Name
 	} else {
-		name = NameToString(supplier.People[0].Name)
+		name = nameToString(supplier.People[0].Name)
 	}
 	seller := &Seller{
-		Address: NewAddress(supplier.Addresses[0]),
+		Address: newAddress(supplier.Addresses[0]),
 		NIP:     string(supplier.TaxID.Code),
 		Name:    name,
 	}
@@ -110,7 +110,7 @@ func NewBuyer(customer *org.Party) *Buyer {
 	// TODO NrVatUE and UECode if applicable
 
 	if len(customer.Addresses) > 0 {
-		buyer.Address = NewAddress(customer.Addresses[0])
+		buyer.Address = newAddress(customer.Addresses[0])
 	}
 
 	if len(customer.Telephones) > 0 {


### PR DESCRIPTION
Our current implementation did not mark every field that can be omited as such. This could make it so empty fields would be still present in the generated xml files which we don't want.

In the commit we mark optional fields with the omitempty keyword and we also make some methods that are only used internally less visible outside.