### PR TITLE
Fix missing FormaPlatnosci for single advance payments

### DIFF
--- a/payments.go
+++ b/payments.go
@@ -124,6 +124,9 @@ func NewPayment(pay *bill.PaymentDetails, totals *bill.Totals) *Payment {
 			if advances[0].Date != nil {
 				payment.PaymentDate = advances[0].Date.String()
 			}
+			if code := advances[0].Ext.Get(favat.ExtKeyPaymentMeans).String(); code != "" {
+				payment.PaymentMean = code
+			}
 		} else {
 			if totals.Due.IsZero() {
 				// Invoice already paid in full in multiple payments

--- a/payments_test.go
+++ b/payments_test.go
@@ -199,6 +199,45 @@ func TestNewPayment(t *testing.T) {
 		assert.Equal(t, result, pay)
 	})
 
+	t.Run("single advance with payment means should set FormaPlatnosci", func(t *testing.T) {
+		x := time.Date(2023, time.July, 28, 0, 0, 0, 0, time.UTC)
+		d := cal.DateOf(x)
+		amt, err := num.AmountFromString("245.890")
+		require.NoError(t, err)
+		zero, err := num.AmountFromString("0")
+		require.NoError(t, err)
+
+		payment := &bill.PaymentDetails{
+			Advances: []*pay.Advance{{
+				Date:   &d,
+				Amount: amt,
+				Ext: tax.Extensions{
+					favat.ExtKeyPaymentMeans: "1", // cash
+				},
+			}},
+		}
+		totals := &bill.Totals{
+			Due:      &zero,
+			Advances: &amt,
+		}
+		pay := ksef.NewPayment(payment, totals)
+		result := &ksef.Payment{
+			PaidMarker:             "1",
+			PaymentDate:            d.String(),
+			PartiallyPaidMarker:    "",
+			AdvancePayments:        []*ksef.AdvancePayment{},
+			DueDates:               []*ksef.DueDate{},
+			PaymentMean:            "1",
+			OtherPaymentMeanMarker: "",
+			OtherPaymentMean:       "",
+			BankAccounts:           []*ksef.BankAccount(nil),
+			FactorBankAccounts:     []*ksef.BankAccount(nil),
+			Discount:               (*ksef.Discount)(nil),
+		}
+
+		assert.Equal(t, result, pay)
+	})
+
 	t.Run("multiple advances sets partially paid marker and advance fields", func(t *testing.T) {
 		// Partially paid in advance
 		x := time.Date(2023, time.July, 28, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- When a single advance fully pays an invoice, the `pl-favat-payment-means` extension was not mapped to the `FormaPlatnosci` XML element — only `Zaplacono` and `DataZaplaty` were set, silently dropping the payment means code.
- The fix reads the extension from the advance and sets `FormaPlatnosci` on the top-level `Platnosc` element, consistent with how the reverse path (KSeF → GOBL) already handled it.
- Added a test case covering this scenario.

## Test plan
- [x] New unit test: single advance with `pl-favat-payment-means` extension produces `PaymentMean` on the `Payment` struct
- [x] Existing tests pass (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)