### PR TITLE
Clarify rounding mismatch error message

### DIFF
--- a/rounding.go
+++ b/rounding.go
@@ -9,17 +9,23 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// RoundingError represents a rounding discrepancy that exceeded acceptable thresholds.
-// When this error is returned, the inv parameter passed to AdjustRounding has had the
-// rounding adjustment applied, allowing callers to use it despite the warning.
+// RoundingError indicates that the total calculated from the GOBL invoice does
+// not match the total reported by KSeF, and the difference is larger than what
+// can be attributed to rounding. When this error is returned, the inv parameter
+// passed to AdjustRounding has had the difference applied as a rounding
+// adjustment anyway, allowing callers to use it despite the warning.
 type RoundingError struct {
+	Calculated num.Amount
+	Expected   num.Amount
 	Diff       num.Amount
 	MaxAllowed num.Amount
 }
 
 func (e *RoundingError) Error() string {
-	return fmt.Sprintf("rounding error in totals too high: %s (max allowed: %s)",
-		e.Diff.String(), e.MaxAllowed.String())
+	return fmt.Sprintf(
+		"calculated GOBL total (%s) does not match KSeF total (%s): difference of %s exceeds rounding tolerance of %s",
+		e.Calculated.String(), e.Expected.String(), e.Diff.String(), e.MaxAllowed.String(),
+	)
 }
 
 // AdjustRounding checks and, if needed, adjusts the rounding in the GOBL invoice to match the
@@ -72,6 +78,8 @@ func AdjustRounding(inv *bill.Invoice, ksefTotalDue string) error {
 		// Too much difference. Apply the adjustment anyway and return a warning
 		inv.Totals.Rounding = &diff
 		return &RoundingError{
+			Calculated: calculatedTotal,
+			Expected:   expectedTotal,
 			Diff:       diff,
 			MaxAllowed: maxErr,
 		}

--- a/rounding_test.go
+++ b/rounding_test.go
@@ -322,14 +322,23 @@ func TestAdjustRounding(t *testing.T) {
 		err := inv.Calculate()
 		require.NoError(t, err)
 
+		calculated := inv.Totals.Payable
 		// Add a large difference (1.00 PLN - way beyond acceptable rounding)
-		expectedTotal := inv.Totals.Payable.Add(num.MakeAmount(100, 2))
+		expectedTotal := calculated.Add(num.MakeAmount(100, 2))
 
 		// Now test - should fail
 		inv2 := baseInvoice()
 		err = ksef.AdjustRounding(inv2, expectedTotal.String())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not match KSeF total")
+
+		var rerr *ksef.RoundingError
+		require.ErrorAs(t, err, &rerr)
+		assert.Equal(t, calculated.String(), rerr.Calculated.String())
+		assert.Equal(t, expectedTotal.String(), rerr.Expected.String())
+		assert.Equal(t, "1.00", rerr.Diff.String())
+		// 1 line × 0.01 subunit tolerance for PLN
+		assert.Equal(t, "0.01", rerr.MaxAllowed.String())
 	})
 
 	t.Run("handles invoice with advances", func(t *testing.T) {

--- a/rounding_test.go
+++ b/rounding_test.go
@@ -329,7 +329,7 @@ func TestAdjustRounding(t *testing.T) {
 		inv2 := baseInvoice()
 		err = ksef.AdjustRounding(inv2, expectedTotal.String())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "rounding error in totals too high")
+		assert.Contains(t, err.Error(), "does not match KSeF total")
 	})
 
 	t.Run("handles invoice with advances", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rephrase the error returned when GOBL totals diverge from KSeF totals by more than rounding can explain — the new message names both totals so clients can see which side disagrees and frames the threshold as a rounding tolerance, not the problem itself.
- Add `Calculated` and `Expected` fields to `RoundingError` for programmatic access.

The previous wording (`rounding error in totals too high: 0.50 (max allowed: 0.02)`) was confusing for clients because it suggested rounding was the cause when in fact the calculated GOBL total simply did not match the value KSeF expected.

## Test plan
- [x] `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)