### PR TITLE
Preserve unrecognized KSeF units in Item.Meta

### DIFF
--- a/lines.go
+++ b/lines.go
@@ -223,18 +223,20 @@ func (l *Line) ToGOBL() (*bill.Line, error) {
 
 	// Parse unit of measure. KSeF accepts free-form unit strings (e.g. "kilo",
 	// "pcs."), but GOBL only accepts its own defined unit keys or 2-3 letter
-	// UN/ECE codes. When the measure is not a valid GOBL unit, preserve the
-	// original value under Item.Meta["unit-label"] so the information is not
-	// lost while keeping the resulting invoice valid.
-	if l.Measure != "" {
-		unit := org.Unit(l.Measure)
+	// UN/ECE codes. Trim surrounding whitespace before validating so that
+	// user-entered values like " KGM " are still recognized as canonical.
+	// When the measure is not a valid GOBL unit, preserve the trimmed value
+	// under Item.Meta["unit-label"] so the information is not lost while
+	// keeping the resulting invoice valid.
+	if measure := strings.TrimSpace(l.Measure); measure != "" {
+		unit := org.Unit(measure)
 		if err := unit.Validate(); err == nil {
 			line.Item.Unit = unit
 		} else {
 			if line.Item.Meta == nil {
 				line.Item.Meta = cbc.Meta{}
 			}
-			line.Item.Meta[metaKeyUnitLabel] = l.Measure
+			line.Item.Meta[metaKeyUnitLabel] = measure
 		}
 	}
 

--- a/lines.go
+++ b/lines.go
@@ -12,9 +12,11 @@ import (
 	"github.com/invopop/gobl/uuid"
 )
 
-// metaKeyUnit holds the original KSeF unit of measure when it does not match
-// a value accepted by GOBL (neither a defined unit nor a UN/ECE code).
-const metaKeyUnit cbc.Key = "unit"
+// metaKeyUnitLabel holds the original KSeF unit of measure when it does not
+// match a value accepted by GOBL (neither a defined unit nor a UN/ECE code).
+// The "-label" suffix marks it as a free-form human-readable label rather
+// than a canonical unit code.
+const metaKeyUnitLabel cbc.Key = "unit-label"
 
 // Line defines the XML structure for KSeF item line (element type FaWiersz, for VAT and KOR type invoices)
 type Line struct {
@@ -134,11 +136,11 @@ func vatRate(tc *tax.Combo) string {
 }
 
 // lineMeasure resolves the KSeF P_8A unit of measure. When the GOBL item has
-// an Item.Meta["unit"] entry — typically set by ToGOBL for KSeF units that do
-// not match a GOBL or UN/ECE code — that original value is used so KSeF
-// round-trips preserve the supplier's wording.
+// an Item.Meta["unit-label"] entry — typically set by ToGOBL for KSeF units
+// that do not match a GOBL or UN/ECE code — that original value is used so
+// KSeF round-trips preserve the supplier's wording.
 func lineMeasure(line *bill.Line) string {
-	if u, ok := line.Item.Meta[metaKeyUnit]; ok && u != "" {
+	if u, ok := line.Item.Meta[metaKeyUnitLabel]; ok && u != "" {
 		return u
 	}
 	return string(line.Item.Unit.UNECE())
@@ -222,8 +224,8 @@ func (l *Line) ToGOBL() (*bill.Line, error) {
 	// Parse unit of measure. KSeF accepts free-form unit strings (e.g. "kilo",
 	// "pcs."), but GOBL only accepts its own defined unit keys or 2-3 letter
 	// UN/ECE codes. When the measure is not a valid GOBL unit, preserve the
-	// original value under Item.Meta["unit"] so the information is not lost
-	// while keeping the resulting invoice valid.
+	// original value under Item.Meta["unit-label"] so the information is not
+	// lost while keeping the resulting invoice valid.
 	if l.Measure != "" {
 		unit := org.Unit(l.Measure)
 		if err := unit.Validate(); err == nil {
@@ -232,7 +234,7 @@ func (l *Line) ToGOBL() (*bill.Line, error) {
 			if line.Item.Meta == nil {
 				line.Item.Meta = cbc.Meta{}
 			}
-			line.Item.Meta[metaKeyUnit] = l.Measure
+			line.Item.Meta[metaKeyUnitLabel] = l.Measure
 		}
 	}
 

--- a/lines.go
+++ b/lines.go
@@ -12,6 +12,10 @@ import (
 	"github.com/invopop/gobl/uuid"
 )
 
+// metaKeyUnit holds the original KSeF unit of measure when it does not match
+// a value accepted by GOBL (neither a defined unit nor a UN/ECE code).
+const metaKeyUnit cbc.Key = "unit"
+
 // Line defines the XML structure for KSeF item line (element type FaWiersz, for VAT and KOR type invoices)
 type Line struct {
 	LineNumber              int    `xml:"NrWierszaFa"`
@@ -73,7 +77,7 @@ func newLine(line *bill.Line, pricesIncludeVAT bool) *Line {
 		LineNumber: line.Index,
 		UniqueID:   string(line.UUID),
 		Name:       line.Item.Name,
-		Measure:    string(line.Item.Unit.UNECE()),
+		Measure:    lineMeasure(line),
 		Quantity:   line.Quantity.String(),
 		Discount:   lineDiscount(line),
 	}
@@ -127,6 +131,17 @@ func vatRate(tc *tax.Combo) string {
 	default:
 		return ""
 	}
+}
+
+// lineMeasure resolves the KSeF P_8A unit of measure. When the GOBL item has
+// an Item.Meta["unit"] entry — typically set by ToGOBL for KSeF units that do
+// not match a GOBL or UN/ECE code — that original value is used so KSeF
+// round-trips preserve the supplier's wording.
+func lineMeasure(line *bill.Line) string {
+	if u, ok := line.Item.Meta[metaKeyUnit]; ok && u != "" {
+		return u
+	}
+	return string(line.Item.Unit.UNECE())
 }
 
 func lineDiscount(line *bill.Line) string {
@@ -204,9 +219,21 @@ func (l *Line) ToGOBL() (*bill.Line, error) {
 		}
 	}
 
-	// Parse unit of measure
+	// Parse unit of measure. KSeF accepts free-form unit strings (e.g. "kilo",
+	// "pcs."), but GOBL only accepts its own defined unit keys or 2-3 letter
+	// UN/ECE codes. When the measure is not a valid GOBL unit, preserve the
+	// original value under Item.Meta["unit"] so the information is not lost
+	// while keeping the resulting invoice valid.
 	if l.Measure != "" {
-		line.Item.Unit = org.Unit(l.Measure)
+		unit := org.Unit(l.Measure)
+		if err := unit.Validate(); err == nil {
+			line.Item.Unit = unit
+		} else {
+			if line.Item.Meta == nil {
+				line.Item.Meta = cbc.Meta{}
+			}
+			line.Item.Meta[metaKeyUnit] = l.Measure
+		}
 	}
 
 	// Parse discount — P_10 is the total line discount per the KSeF spec,

--- a/lines_test.go
+++ b/lines_test.go
@@ -241,7 +241,7 @@ func TestNewLines(t *testing.T) {
 		assert.Empty(t, result[0].NetPriceTotal)
 	})
 
-	t.Run("uses Item.Meta unit when set", func(t *testing.T) {
+	t.Run("uses Item.Meta unit-label when set", func(t *testing.T) {
 		price, _ := num.AmountFromString("100.00")
 		qty, _ := num.AmountFromString("1")
 		total, _ := num.AmountFromString("100.00")
@@ -253,7 +253,7 @@ func TestNewLines(t *testing.T) {
 				Item: &org.Item{
 					Name:  "Item with non-GOBL unit",
 					Price: &price,
-					Meta:  cbc.Meta{"unit": "kilo"},
+					Meta:  cbc.Meta{"unit-label": "kilo"},
 				},
 				Total: &total,
 				Taxes: tax.Set{
@@ -561,7 +561,7 @@ func TestLineToGOBL(t *testing.T) {
 		assert.Equal(t, org.Unit("h"), line.Item.Unit)
 	})
 
-	t.Run("preserves invalid unit under Item.Meta", func(t *testing.T) {
+	t.Run("preserves invalid unit under Item.Meta unit-label", func(t *testing.T) {
 		ksefLine := &ksef.Line{
 			Name:         "Item with non-GOBL unit",
 			Quantity:     "1",
@@ -574,7 +574,7 @@ func TestLineToGOBL(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, org.Unit(""), line.Item.Unit)
-		assert.Equal(t, "szt", line.Item.Meta["unit"])
+		assert.Equal(t, "szt", line.Item.Meta["unit-label"])
 		assert.NoError(t, line.Item.Unit.Validate())
 	})
 

--- a/lines_test.go
+++ b/lines_test.go
@@ -6,6 +6,7 @@ import (
 	ksef "github.com/invopop/gobl.ksef"
 	"github.com/invopop/gobl/addons/pl/favat"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
@@ -238,6 +239,36 @@ func TestNewLines(t *testing.T) {
 		assert.Equal(t, "35.00", result[0].GrossPriceTotal)
 		assert.Empty(t, result[0].NetUnitPrice)
 		assert.Empty(t, result[0].NetPriceTotal)
+	})
+
+	t.Run("uses Item.Meta unit when set", func(t *testing.T) {
+		price, _ := num.AmountFromString("100.00")
+		qty, _ := num.AmountFromString("1")
+		total, _ := num.AmountFromString("100.00")
+
+		lines := []*bill.Line{
+			{
+				Index:    1,
+				Quantity: qty,
+				Item: &org.Item{
+					Name:  "Item with non-GOBL unit",
+					Price: &price,
+					Meta:  cbc.Meta{"unit": "kilo"},
+				},
+				Total: &total,
+				Taxes: tax.Set{
+					&tax.Combo{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(23, 2),
+					},
+				},
+			},
+		}
+
+		result := ksef.NewLines(lines)
+
+		require.Len(t, result, 1)
+		assert.Equal(t, "kilo", result[0].Measure)
 	})
 }
 
@@ -528,6 +559,23 @@ func TestLineToGOBL(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, org.Unit("h"), line.Item.Unit)
+	})
+
+	t.Run("preserves invalid unit under Item.Meta", func(t *testing.T) {
+		ksefLine := &ksef.Line{
+			Name:         "Item with non-GOBL unit",
+			Quantity:     "1",
+			NetUnitPrice: "100.00",
+			Measure:      "szt",
+			VATRate:      "23",
+		}
+
+		line, err := ksefLine.ToGOBL()
+
+		require.NoError(t, err)
+		assert.Equal(t, org.Unit(""), line.Item.Unit)
+		assert.Equal(t, "szt", line.Item.Meta["unit"])
+		assert.NoError(t, line.Item.Unit.Validate())
 	})
 
 	t.Run("maps discount directly from P_10", func(t *testing.T) {

--- a/lines_test.go
+++ b/lines_test.go
@@ -578,6 +578,38 @@ func TestLineToGOBL(t *testing.T) {
 		assert.NoError(t, line.Item.Unit.Validate())
 	})
 
+	t.Run("trims whitespace around measure", func(t *testing.T) {
+		ksefLine := &ksef.Line{
+			Name:         "Padded canonical unit",
+			Quantity:     "1",
+			NetUnitPrice: "100.00",
+			Measure:      "  KGM  ",
+			VATRate:      "23",
+		}
+
+		line, err := ksefLine.ToGOBL()
+
+		require.NoError(t, err)
+		assert.Equal(t, org.Unit("KGM"), line.Item.Unit)
+		assert.Empty(t, line.Item.Meta["unit-label"])
+	})
+
+	t.Run("trims whitespace around non-canonical measure", func(t *testing.T) {
+		ksefLine := &ksef.Line{
+			Name:         "Padded label unit",
+			Quantity:     "1",
+			NetUnitPrice: "100.00",
+			Measure:      "  szt  ",
+			VATRate:      "23",
+		}
+
+		line, err := ksefLine.ToGOBL()
+
+		require.NoError(t, err)
+		assert.Equal(t, org.Unit(""), line.Item.Unit)
+		assert.Equal(t, "szt", line.Item.Meta["unit-label"])
+	})
+
 	t.Run("maps discount directly from P_10", func(t *testing.T) {
 		// Auchan-style data: P_9B=5.98, qty=2, P_10=2.40, P_11A=9.56
 		ksefLine := &ksef.Line{

--- a/test/data/ksef.gobl/out/credit-note-before-after.json
+++ b/test/data/ksef.gobl/out/credit-note-before-after.json
@@ -70,7 +70,9 @@
         "item": {
           "name": "Vehicle pickup within city limits",
           "price": "48.78",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "-48.78",
         "taxes": [
@@ -92,7 +94,9 @@
         "item": {
           "name": "Vehicle rental, class A, 2026-02-10 to 2026-02-16",
           "price": "190.00",
-          "unit": "d"
+          "meta": {
+            "unit": "d"
+          }
         },
         "sum": "-1140.00",
         "taxes": [
@@ -115,7 +119,9 @@
         "item": {
           "name": "Vehicle rental, class A, 2026-02-10 to 2026-02-16",
           "price": "190.00",
-          "unit": "d"
+          "meta": {
+            "unit": "d"
+          }
         },
         "sum": "1140.00",
         "taxes": [
@@ -142,7 +148,9 @@
         "item": {
           "name": "Insurance package, 2026-02-10 to 2026-02-16",
           "price": "36.59",
-          "unit": "d"
+          "meta": {
+            "unit": "d"
+          }
         },
         "sum": "-219.54",
         "taxes": [
@@ -164,7 +172,9 @@
         "item": {
           "name": "Insurance package, 2026-02-10 to 2026-02-16",
           "price": "36.59",
-          "unit": "d"
+          "meta": {
+            "unit": "d"
+          }
         },
         "sum": "219.54",
         "taxes": [
@@ -240,7 +250,9 @@
         "item": {
           "name": "Initial delivery fee",
           "price": "48.78",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "-48.78",
         "taxes": [
@@ -262,7 +274,9 @@
         "item": {
           "name": "Initial delivery fee",
           "price": "48.78",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "48.78",
         "taxes": [

--- a/test/data/ksef.gobl/out/credit-note-before-after.json
+++ b/test/data/ksef.gobl/out/credit-note-before-after.json
@@ -71,7 +71,7 @@
           "name": "Vehicle pickup within city limits",
           "price": "48.78",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "-48.78",
@@ -95,7 +95,7 @@
           "name": "Vehicle rental, class A, 2026-02-10 to 2026-02-16",
           "price": "190.00",
           "meta": {
-            "unit": "d"
+            "unit-label": "d"
           }
         },
         "sum": "-1140.00",
@@ -120,7 +120,7 @@
           "name": "Vehicle rental, class A, 2026-02-10 to 2026-02-16",
           "price": "190.00",
           "meta": {
-            "unit": "d"
+            "unit-label": "d"
           }
         },
         "sum": "1140.00",
@@ -149,7 +149,7 @@
           "name": "Insurance package, 2026-02-10 to 2026-02-16",
           "price": "36.59",
           "meta": {
-            "unit": "d"
+            "unit-label": "d"
           }
         },
         "sum": "-219.54",
@@ -173,7 +173,7 @@
           "name": "Insurance package, 2026-02-10 to 2026-02-16",
           "price": "36.59",
           "meta": {
-            "unit": "d"
+            "unit-label": "d"
           }
         },
         "sum": "219.54",
@@ -251,7 +251,7 @@
           "name": "Initial delivery fee",
           "price": "48.78",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "-48.78",
@@ -275,7 +275,7 @@
           "name": "Initial delivery fee",
           "price": "48.78",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "48.78",

--- a/test/data/ksef.gobl/out/credit-note-payed.json
+++ b/test/data/ksef.gobl/out/credit-note-payed.json
@@ -76,7 +76,7 @@
           "name": "Usługa transportowa Bilet Nr: 000001",
           "price": "87.00",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "87.00",
@@ -106,7 +106,7 @@
           "name": "Usługa transportowa Bilet Nr: 000001",
           "price": "0.00",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "0.00",

--- a/test/data/ksef.gobl/out/credit-note-payed.json
+++ b/test/data/ksef.gobl/out/credit-note-payed.json
@@ -75,7 +75,9 @@
         "item": {
           "name": "Usługa transportowa Bilet Nr: 000001",
           "price": "87.00",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "87.00",
         "taxes": [
@@ -103,7 +105,9 @@
         "item": {
           "name": "Usługa transportowa Bilet Nr: 000001",
           "price": "0.00",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "0.00",
         "taxes": [

--- a/test/data/ksef.gobl/out/discount-invoice.json
+++ b/test/data/ksef.gobl/out/discount-invoice.json
@@ -59,7 +59,7 @@
           "name": "Product 1",
           "price": "9.98",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "19.96",
@@ -83,7 +83,7 @@
           "name": "Product 2",
           "price": "3.58",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "3.58",
@@ -107,7 +107,7 @@
           "name": "Product 3",
           "price": "5.79",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "5.79",
@@ -131,7 +131,7 @@
           "name": "Product 4",
           "price": "5.79",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "5.79",
@@ -160,7 +160,7 @@
           "name": "Product 5",
           "price": "5.98",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "11.96",
@@ -189,7 +189,7 @@
           "name": "Product 6",
           "price": "5.55",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "11.10",
@@ -218,7 +218,7 @@
           "name": "Product 7",
           "price": "6.34",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "19.02",
@@ -247,7 +247,7 @@
           "name": "Product 8",
           "price": "4.37",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "17.48",
@@ -276,7 +276,7 @@
           "name": "Product 9",
           "price": "6.98",
           "meta": {
-            "unit": "Kg."
+            "unit-label": "Kg."
           }
         },
         "sum": "13.58",
@@ -305,7 +305,7 @@
           "name": "Product 10",
           "price": "5.31",
           "meta": {
-            "unit": "Szt."
+            "unit-label": "Szt."
           }
         },
         "sum": "10.62",

--- a/test/data/ksef.gobl/out/discount-invoice.json
+++ b/test/data/ksef.gobl/out/discount-invoice.json
@@ -58,7 +58,9 @@
         "item": {
           "name": "Product 1",
           "price": "9.98",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "19.96",
         "taxes": [
@@ -80,7 +82,9 @@
         "item": {
           "name": "Product 2",
           "price": "3.58",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "3.58",
         "taxes": [
@@ -102,7 +106,9 @@
         "item": {
           "name": "Product 3",
           "price": "5.79",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "5.79",
         "taxes": [
@@ -124,7 +130,9 @@
         "item": {
           "name": "Product 4",
           "price": "5.79",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "5.79",
         "discounts": [
@@ -151,7 +159,9 @@
         "item": {
           "name": "Product 5",
           "price": "5.98",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "11.96",
         "discounts": [
@@ -178,7 +188,9 @@
         "item": {
           "name": "Product 6",
           "price": "5.55",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "11.10",
         "discounts": [
@@ -205,7 +217,9 @@
         "item": {
           "name": "Product 7",
           "price": "6.34",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "19.02",
         "discounts": [
@@ -232,7 +246,9 @@
         "item": {
           "name": "Product 8",
           "price": "4.37",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "17.48",
         "discounts": [
@@ -259,7 +275,9 @@
         "item": {
           "name": "Product 9",
           "price": "6.98",
-          "unit": "Kg."
+          "meta": {
+            "unit": "Kg."
+          }
         },
         "sum": "13.58",
         "discounts": [
@@ -286,7 +304,9 @@
         "item": {
           "name": "Product 10",
           "price": "5.31",
-          "unit": "Szt."
+          "meta": {
+            "unit": "Szt."
+          }
         },
         "sum": "10.62",
         "discounts": [

--- a/test/data/ksef.gobl/out/long-invoice.json
+++ b/test/data/ksef.gobl/out/long-invoice.json
@@ -70,7 +70,9 @@
         "item": {
           "name": "Opakowanie zbiorcze (w tym opłata środowiskowa)",
           "price": "5.95",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "5.95",
         "taxes": [
@@ -92,7 +94,9 @@
         "item": {
           "name": "Serek naturalny 200g",
           "price": "3.86",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "15.44",
         "taxes": [
@@ -114,7 +118,9 @@
         "item": {
           "name": "Serek owocowy brzoskwinia 150g",
           "price": "3.79",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "7.58",
         "taxes": [
@@ -136,7 +142,9 @@
         "item": {
           "name": "Serek owocowy truskawka 150g",
           "price": "3.79",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "7.58",
         "taxes": [
@@ -158,7 +166,9 @@
         "item": {
           "name": "Kefir tradycyjny 1,5% 400ml",
           "price": "3.29",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "6.58",
         "taxes": [
@@ -180,7 +190,9 @@
         "item": {
           "name": "Napój mleczny czekoladowy 250ml",
           "price": "3.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "59.85",
         "taxes": [
@@ -202,7 +214,9 @@
         "item": {
           "name": "Jogurt naturalny 370g",
           "price": "1.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "5.97",
         "taxes": [
@@ -224,7 +238,9 @@
         "item": {
           "name": "Orzechy włoskie 100g",
           "price": "6.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "41.94",
         "taxes": [
@@ -246,7 +262,9 @@
         "item": {
           "name": "Orzechy nerkowca 150g",
           "price": "9.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "49.95",
         "taxes": [
@@ -268,7 +286,9 @@
         "item": {
           "name": "Jogurt naturalny bez laktozy 370g",
           "price": "2.89",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "2.89",
         "taxes": [
@@ -290,7 +310,9 @@
         "item": {
           "name": "Szynka konserwowa 300g",
           "price": "6.35",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "6.35",
         "taxes": [
@@ -312,7 +334,9 @@
         "item": {
           "name": "Serek wiejski bez laktozy 200g",
           "price": "4.39",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "13.17",
         "taxes": [
@@ -334,7 +358,9 @@
         "item": {
           "name": "Kefir bez laktozy z probiotykiem 1,5% 400ml",
           "price": "3.69",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "7.38",
         "taxes": [
@@ -356,7 +382,9 @@
         "item": {
           "name": "Mieszanka orzechów 200g",
           "price": "9.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "49.95",
         "taxes": [
@@ -378,7 +406,9 @@
         "item": {
           "name": "Produkt sojowy jagodowy 400g",
           "price": "4.89",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "9.78",
         "taxes": [
@@ -400,7 +430,9 @@
         "item": {
           "name": "Produkt sojowy brzoskwiniowy 400g",
           "price": "4.89",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "9.78",
         "taxes": [
@@ -422,7 +454,9 @@
         "item": {
           "name": "Paluszki serowe 80g",
           "price": "6.19",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "30.95",
         "taxes": [
@@ -444,7 +478,9 @@
         "item": {
           "name": "Beef jerky proteinowy 25g",
           "price": "10.45",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "83.60",
         "taxes": [
@@ -466,7 +502,9 @@
         "item": {
           "name": "Kabanosy drobiowe bezglutenowe 120g",
           "price": "6.49",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "64.90",
         "taxes": [
@@ -488,7 +526,9 @@
         "item": {
           "name": "Jogurt pitny jagodowy 330ml",
           "price": "5.85",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "58.50",
         "taxes": [
@@ -510,7 +550,9 @@
         "item": {
           "name": "Jogurt pitny mango marakuja 330ml",
           "price": "5.85",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "29.25",
         "taxes": [
@@ -532,7 +574,9 @@
         "item": {
           "name": "Kiełbasa krakowska sucha 250g",
           "price": "8.39",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "8.39",
         "taxes": [
@@ -554,7 +598,9 @@
         "item": {
           "name": "Mus owocowy jabłko 120g",
           "price": "3.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "23.94",
         "taxes": [
@@ -576,7 +622,9 @@
         "item": {
           "name": "Mus owocowy jabłko truskawka 120g",
           "price": "3.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "39.90",
         "taxes": [
@@ -598,7 +646,9 @@
         "item": {
           "name": "Serek wiejski wysokobiałkowy 200g",
           "price": "4.39",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "17.56",
         "taxes": [
@@ -620,7 +670,9 @@
         "item": {
           "name": "Jogurt pitny wanilia 330ml",
           "price": "5.85",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "29.25",
         "taxes": [
@@ -642,7 +694,9 @@
         "item": {
           "name": "Jogurt pitny truskawka \u0026 kiwi 330ml",
           "price": "5.85",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "58.50",
         "taxes": [
@@ -664,7 +718,9 @@
         "item": {
           "name": "Mus owocowy jabłko mango 120g",
           "price": "3.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "59.85",
         "taxes": [
@@ -686,7 +742,9 @@
         "item": {
           "name": "Pudding proteinowy czekoladowy 200g",
           "price": "6.75",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "20.25",
         "taxes": [
@@ -708,7 +766,9 @@
         "item": {
           "name": "Pudding proteinowy waniliowy 200g",
           "price": "6.75",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "20.25",
         "taxes": [
@@ -730,7 +790,9 @@
         "item": {
           "name": "Pudding proteinowy ryżowy 200g",
           "price": "6.75",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "20.25",
         "taxes": [
@@ -752,7 +814,9 @@
         "item": {
           "name": "Chleb tostowy pszenny 550g",
           "price": "6.99",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "6.99",
         "taxes": [
@@ -774,7 +838,9 @@
         "item": {
           "name": "Jogurt sojowy truskawka-porzeczka-malina 400g",
           "price": "6.95",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "13.90",
         "taxes": [
@@ -796,7 +862,9 @@
         "item": {
           "name": "Jogurt sojowy mango-banan 400g",
           "price": "6.95",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "13.90",
         "taxes": [
@@ -818,7 +886,9 @@
         "item": {
           "name": "Pudding proteinowy biała czekolada 200g",
           "price": "6.75",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "20.25",
         "taxes": [
@@ -840,7 +910,9 @@
         "item": {
           "name": "Jogurt pitny nektarynka malina 330ml",
           "price": "5.89",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "29.45",
         "taxes": [

--- a/test/data/ksef.gobl/out/long-invoice.json
+++ b/test/data/ksef.gobl/out/long-invoice.json
@@ -71,7 +71,7 @@
           "name": "Opakowanie zbiorcze (w tym opłata środowiskowa)",
           "price": "5.95",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "5.95",
@@ -95,7 +95,7 @@
           "name": "Serek naturalny 200g",
           "price": "3.86",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "15.44",
@@ -119,7 +119,7 @@
           "name": "Serek owocowy brzoskwinia 150g",
           "price": "3.79",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "7.58",
@@ -143,7 +143,7 @@
           "name": "Serek owocowy truskawka 150g",
           "price": "3.79",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "7.58",
@@ -167,7 +167,7 @@
           "name": "Kefir tradycyjny 1,5% 400ml",
           "price": "3.29",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "6.58",
@@ -191,7 +191,7 @@
           "name": "Napój mleczny czekoladowy 250ml",
           "price": "3.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "59.85",
@@ -215,7 +215,7 @@
           "name": "Jogurt naturalny 370g",
           "price": "1.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "5.97",
@@ -239,7 +239,7 @@
           "name": "Orzechy włoskie 100g",
           "price": "6.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "41.94",
@@ -263,7 +263,7 @@
           "name": "Orzechy nerkowca 150g",
           "price": "9.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "49.95",
@@ -287,7 +287,7 @@
           "name": "Jogurt naturalny bez laktozy 370g",
           "price": "2.89",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "2.89",
@@ -311,7 +311,7 @@
           "name": "Szynka konserwowa 300g",
           "price": "6.35",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "6.35",
@@ -335,7 +335,7 @@
           "name": "Serek wiejski bez laktozy 200g",
           "price": "4.39",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "13.17",
@@ -359,7 +359,7 @@
           "name": "Kefir bez laktozy z probiotykiem 1,5% 400ml",
           "price": "3.69",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "7.38",
@@ -383,7 +383,7 @@
           "name": "Mieszanka orzechów 200g",
           "price": "9.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "49.95",
@@ -407,7 +407,7 @@
           "name": "Produkt sojowy jagodowy 400g",
           "price": "4.89",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "9.78",
@@ -431,7 +431,7 @@
           "name": "Produkt sojowy brzoskwiniowy 400g",
           "price": "4.89",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "9.78",
@@ -455,7 +455,7 @@
           "name": "Paluszki serowe 80g",
           "price": "6.19",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "30.95",
@@ -479,7 +479,7 @@
           "name": "Beef jerky proteinowy 25g",
           "price": "10.45",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "83.60",
@@ -503,7 +503,7 @@
           "name": "Kabanosy drobiowe bezglutenowe 120g",
           "price": "6.49",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "64.90",
@@ -527,7 +527,7 @@
           "name": "Jogurt pitny jagodowy 330ml",
           "price": "5.85",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "58.50",
@@ -551,7 +551,7 @@
           "name": "Jogurt pitny mango marakuja 330ml",
           "price": "5.85",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "29.25",
@@ -575,7 +575,7 @@
           "name": "Kiełbasa krakowska sucha 250g",
           "price": "8.39",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "8.39",
@@ -599,7 +599,7 @@
           "name": "Mus owocowy jabłko 120g",
           "price": "3.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "23.94",
@@ -623,7 +623,7 @@
           "name": "Mus owocowy jabłko truskawka 120g",
           "price": "3.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "39.90",
@@ -647,7 +647,7 @@
           "name": "Serek wiejski wysokobiałkowy 200g",
           "price": "4.39",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "17.56",
@@ -671,7 +671,7 @@
           "name": "Jogurt pitny wanilia 330ml",
           "price": "5.85",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "29.25",
@@ -695,7 +695,7 @@
           "name": "Jogurt pitny truskawka \u0026 kiwi 330ml",
           "price": "5.85",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "58.50",
@@ -719,7 +719,7 @@
           "name": "Mus owocowy jabłko mango 120g",
           "price": "3.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "59.85",
@@ -743,7 +743,7 @@
           "name": "Pudding proteinowy czekoladowy 200g",
           "price": "6.75",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "20.25",
@@ -767,7 +767,7 @@
           "name": "Pudding proteinowy waniliowy 200g",
           "price": "6.75",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "20.25",
@@ -791,7 +791,7 @@
           "name": "Pudding proteinowy ryżowy 200g",
           "price": "6.75",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "20.25",
@@ -815,7 +815,7 @@
           "name": "Chleb tostowy pszenny 550g",
           "price": "6.99",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "6.99",
@@ -839,7 +839,7 @@
           "name": "Jogurt sojowy truskawka-porzeczka-malina 400g",
           "price": "6.95",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "13.90",
@@ -863,7 +863,7 @@
           "name": "Jogurt sojowy mango-banan 400g",
           "price": "6.95",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "13.90",
@@ -887,7 +887,7 @@
           "name": "Pudding proteinowy biała czekolada 200g",
           "price": "6.75",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "20.25",
@@ -911,7 +911,7 @@
           "name": "Jogurt pitny nektarynka malina 330ml",
           "price": "5.89",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "29.45",

--- a/test/data/ksef.gobl/out/no-unit-price.json
+++ b/test/data/ksef.gobl/out/no-unit-price.json
@@ -304,7 +304,9 @@
         "item": {
           "name": "Tubing 12x2 black",
           "price": "10.8000",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "540.00",
         "taxes": [
@@ -370,7 +372,9 @@
         "item": {
           "name": "Tubing 4x0.75 red",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [
@@ -392,7 +396,9 @@
         "item": {
           "name": "Tubing 4x0.75 blue",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [
@@ -414,7 +420,9 @@
         "item": {
           "name": "Tubing 4x0.75 yellow",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [
@@ -436,7 +444,9 @@
         "item": {
           "name": "Tubing 4x0.75 green",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [
@@ -458,7 +468,9 @@
         "item": {
           "name": "Tubing 4x0.75 black",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [
@@ -480,7 +492,9 @@
         "item": {
           "name": "Tubing 4x0.75 silver",
           "price": "1.7800",
-          "unit": "M"
+          "meta": {
+            "unit": "M"
+          }
         },
         "sum": "89.00",
         "taxes": [

--- a/test/data/ksef.gobl/out/no-unit-price.json
+++ b/test/data/ksef.gobl/out/no-unit-price.json
@@ -305,7 +305,7 @@
           "name": "Tubing 12x2 black",
           "price": "10.8000",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "540.00",
@@ -373,7 +373,7 @@
           "name": "Tubing 4x0.75 red",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",
@@ -397,7 +397,7 @@
           "name": "Tubing 4x0.75 blue",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",
@@ -421,7 +421,7 @@
           "name": "Tubing 4x0.75 yellow",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",
@@ -445,7 +445,7 @@
           "name": "Tubing 4x0.75 green",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",
@@ -469,7 +469,7 @@
           "name": "Tubing 4x0.75 black",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",
@@ -493,7 +493,7 @@
           "name": "Tubing 4x0.75 silver",
           "price": "1.7800",
           "meta": {
-            "unit": "M"
+            "unit-label": "M"
           }
         },
         "sum": "89.00",

--- a/test/data/ksef.gobl/out/settlement-invoice-1.json
+++ b/test/data/ksef.gobl/out/settlement-invoice-1.json
@@ -61,7 +61,9 @@
         "item": {
           "name": "Usługa pakowania - ECO",
           "price": "4.95",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "4.95",
         "taxes": [
@@ -83,7 +85,9 @@
         "item": {
           "name": "Napój aloesowy 500ml",
           "price": "76.20",
-          "unit": "12pak"
+          "meta": {
+            "unit": "12pak"
+          }
         },
         "sum": "304.80",
         "taxes": [
@@ -105,7 +109,9 @@
         "item": {
           "name": "Shot witaminowy Odporność",
           "price": "5.27",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "252.96",
         "taxes": [
@@ -127,7 +133,9 @@
         "item": {
           "name": "Sok 100% grejpfrut 1L",
           "price": "9.49",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "94.90",
         "taxes": [
@@ -149,7 +157,9 @@
         "item": {
           "name": "Kabanosy drobiowe 100g",
           "price": "7.59",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "151.80",
         "taxes": [
@@ -171,7 +181,9 @@
         "item": {
           "name": "Shot witaminowy Uroda",
           "price": "5.27",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "158.10",
         "taxes": [
@@ -193,7 +205,9 @@
         "item": {
           "name": "Espresso z tonikiem 250ml",
           "price": "8.54",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "170.80",
         "taxes": [
@@ -215,7 +229,9 @@
         "item": {
           "name": "Lemoniada grejpfrutowa 330ml",
           "price": "4.74",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "94.80",
         "taxes": [
@@ -237,7 +253,9 @@
         "item": {
           "name": "Espresso z lemoniadą 250ml",
           "price": "8.54",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "170.80",
         "taxes": [
@@ -259,7 +277,9 @@
         "item": {
           "name": "Lemoniada owocowa 330ml",
           "price": "4.74",
-          "unit": "szt"
+          "meta": {
+            "unit": "szt"
+          }
         },
         "sum": "94.80",
         "taxes": [
@@ -281,7 +301,9 @@
         "item": {
           "name": "Sok multiwitamina PET 1L",
           "price": "40.92",
-          "unit": "12pak"
+          "meta": {
+            "unit": "12pak"
+          }
         },
         "sum": "163.68",
         "taxes": [
@@ -303,7 +325,9 @@
         "item": {
           "name": "Sok pomarańczowy PET 1L",
           "price": "40.92",
-          "unit": "12pak"
+          "meta": {
+            "unit": "12pak"
+          }
         },
         "sum": "163.68",
         "taxes": [
@@ -325,7 +349,9 @@
         "item": {
           "name": "Napój energetyczny ZERO tropikalny 250ml",
           "price": "81.84",
-          "unit": "24pak"
+          "meta": {
+            "unit": "24pak"
+          }
         },
         "sum": "327.36",
         "taxes": [

--- a/test/data/ksef.gobl/out/settlement-invoice-1.json
+++ b/test/data/ksef.gobl/out/settlement-invoice-1.json
@@ -62,7 +62,7 @@
           "name": "Usługa pakowania - ECO",
           "price": "4.95",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "4.95",
@@ -86,7 +86,7 @@
           "name": "Napój aloesowy 500ml",
           "price": "76.20",
           "meta": {
-            "unit": "12pak"
+            "unit-label": "12pak"
           }
         },
         "sum": "304.80",
@@ -110,7 +110,7 @@
           "name": "Shot witaminowy Odporność",
           "price": "5.27",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "252.96",
@@ -134,7 +134,7 @@
           "name": "Sok 100% grejpfrut 1L",
           "price": "9.49",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "94.90",
@@ -158,7 +158,7 @@
           "name": "Kabanosy drobiowe 100g",
           "price": "7.59",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "151.80",
@@ -182,7 +182,7 @@
           "name": "Shot witaminowy Uroda",
           "price": "5.27",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "158.10",
@@ -206,7 +206,7 @@
           "name": "Espresso z tonikiem 250ml",
           "price": "8.54",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "170.80",
@@ -230,7 +230,7 @@
           "name": "Lemoniada grejpfrutowa 330ml",
           "price": "4.74",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "94.80",
@@ -254,7 +254,7 @@
           "name": "Espresso z lemoniadą 250ml",
           "price": "8.54",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "170.80",
@@ -278,7 +278,7 @@
           "name": "Lemoniada owocowa 330ml",
           "price": "4.74",
           "meta": {
-            "unit": "szt"
+            "unit-label": "szt"
           }
         },
         "sum": "94.80",
@@ -302,7 +302,7 @@
           "name": "Sok multiwitamina PET 1L",
           "price": "40.92",
           "meta": {
-            "unit": "12pak"
+            "unit-label": "12pak"
           }
         },
         "sum": "163.68",
@@ -326,7 +326,7 @@
           "name": "Sok pomarańczowy PET 1L",
           "price": "40.92",
           "meta": {
-            "unit": "12pak"
+            "unit-label": "12pak"
           }
         },
         "sum": "163.68",
@@ -350,7 +350,7 @@
           "name": "Napój energetyczny ZERO tropikalny 250ml",
           "price": "81.84",
           "meta": {
-            "unit": "24pak"
+            "unit-label": "24pak"
           }
         },
         "sum": "327.36",


### PR DESCRIPTION
## Summary
- KSeF accepts free-form unit-of-measure strings (e.g. `szt`, `kilo`) that GOBL's `org.Unit` rejects because they are neither defined GOBL units nor 2-3 letter UN/ECE codes — leading to invalid invoices on conversion.
- `Line.ToGOBL` now validates the measure and, when it isn't a valid GOBL unit, stores the original string under `Item.Meta["unit"]` instead of `Item.Unit`.
- The GOBL → KSeF path (`newLine`) reads `Item.Meta["unit"]` first, so round-trips re-emit the original `P_8A` text.
- Test fixtures under `test/data/ksef.gobl/out/` were regenerated to reflect the new placement of values like `szt`.

## Test plan
- [x] `go test ./...`
- [x] New unit tests cover both directions: invalid measure → `Meta["unit"]`, and `Meta["unit"]` → KSeF `Measure`.
- [x] Existing valid GOBL/UN-ECE unit tests (`h`, `KGM`, `HUR`) still set `Item.Unit` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)